### PR TITLE
Add refresh token on code authorization flow

### DIFF
--- a/helpers/middleware.js
+++ b/helpers/middleware.js
@@ -54,7 +54,7 @@ const strategy = (req, res, next) => {
 const authenticate = roles => async (req, res, next) => {
   let role = roles;
   if (Array.isArray(roles)) {
-    if (req.role && roles.include(req.role)) {
+    if (req.role && roles.includes(req.role)) {
       role = req.role;
     }
   }

--- a/helpers/middleware.js
+++ b/helpers/middleware.js
@@ -32,7 +32,9 @@ const strategy = (req, res, next) => {
     || req.query.access_token
     || req.body.access_token
     || req.query.code
-    || req.body.code;
+    || req.body.code
+    || req.query.refresh_token
+    || req.body.refresh_token;
   let decoded;
   try {
     decoded = jwt.verify(token, process.env.JWT_SECRET);
@@ -49,7 +51,14 @@ const strategy = (req, res, next) => {
   next();
 };
 
-const authenticate = role => async (req, res, next) => {
+const authenticate = roles => async (req, res, next) => {
+  let role = roles;
+  if (Array.isArray(roles)) {
+    if (req.role && roles.include(req.role)) {
+      role = req.role;
+    }
+  }
+
   if (!req.role || (role && req.role !== role)) {
     res.status(401).json({
       error: 'invalid_grant',
@@ -65,7 +74,7 @@ const authenticate = role => async (req, res, next) => {
     } else {
       next();
     }
-  } else if (req.role === 'code') {
+  } else if (req.role === 'code' || req.role === 'refresh') {
     const secret = req.query.client_secret || req.body.client_secret;
     const app = await apps.findOne({
       where: {

--- a/helpers/token.js
+++ b/helpers/token.js
@@ -30,7 +30,10 @@ const issueAppToken = (proxy, user, scope = []) => {
   return token;
 };
 
-/** Create a new code for application */
+/**
+ * Create an authorization code for application. It can be exchanged to an
+ * access_token or refresh_token. Authorization code expire in 10 min.
+ */
 const issueAppCode = (proxy, user, scope = []) => (
   jwt.sign(
     { role: 'code', proxy, user, scope },
@@ -39,8 +42,20 @@ const issueAppCode = (proxy, user, scope = []) => (
   )
 );
 
+/**
+ * Create a refresh token for application, it can be used to obtain a renewed
+ * access token. Refresh tokens never expire
+ */
+const issueAppRefreshToken = (proxy, user, scope = []) => (
+  jwt.sign(
+    { role: 'refresh', proxy, user, scope },
+    process.env.JWT_SECRET,
+  )
+);
+
 module.exports = {
   issueUserToken,
   issueAppToken,
   issueAppCode,
+  issueAppRefreshToken,
 };

--- a/helpers/token.js
+++ b/helpers/token.js
@@ -31,11 +31,13 @@ const issueAppToken = (proxy, user, scope = []) => {
 };
 
 /** Create a new code for application */
-const issueAppCode = (proxy, user, scope = []) =>
+const issueAppCode = (proxy, user, scope = []) => (
   jwt.sign(
     { role: 'code', proxy, user, scope },
-    process.env.JWT_SECRET
-  );
+    process.env.JWT_SECRET,
+    { expiresIn: 600 }
+  )
+);
 
 module.exports = {
   issueUserToken,

--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -44,7 +44,7 @@ router.all('/api/oauth2/authorize', authenticate('user'), async (req, res) => {
 });
 
 /** Request app access token */
-router.all('/api/oauth2/token', authenticate('code'), (req, res) => {
+router.all('/api/oauth2/token', authenticate(['code', 'refresh']), (req, res) => {
   debug(`Issue app token for user @${req.user} using @${req.proxy} proxy.`);
   const accessToken = issueAppToken(req.proxy, req.user, req.scope);
   const refreshToken = issueAppRefreshToken(req.proxy, req.user, req.scope);

--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const debug = require('debug')('sc2:server');
-const { issueAppToken, issueAppCode } = require('../helpers/token');
+const { issueAppToken, issueAppCode, issueAppRefreshToken } = require('../helpers/token');
 const { authenticate } = require('../helpers/middleware');
 const config = require('../config.json');
 
@@ -47,8 +47,10 @@ router.all('/api/oauth2/authorize', authenticate('user'), async (req, res) => {
 router.all('/api/oauth2/token', authenticate('code'), (req, res) => {
   debug(`Issue app token for user @${req.user} using @${req.proxy} proxy.`);
   const accessToken = issueAppToken(req.proxy, req.user, req.scope);
+  const refreshToken = issueAppRefreshToken(req.proxy, req.user, req.scope);
   res.json({
     access_token: accessToken,
+    refresh_token: refreshToken,
     expires_in: config.token_expiration,
     username: req.user,
   });


### PR DESCRIPTION
Add `refresh_token` to renew `access_token` in the code authorization flow.

- Set authorization code expiration to 10min
- Issue refresh token
- Allow `refresh_token` for issue new `access_token` with `api/oauth2/token` endpoint