### PR TITLE
Fix: the translations

### DIFF
--- a/src/components/Sign.js
+++ b/src/components/Sign.js
@@ -109,7 +109,7 @@ export default class Sign extends Component {
               }
               {step === 'signin' && <SignForm roles={op.roles} sign={this.sign} title="Log in to confirm the operation" />}
               {step === 'signin' && <Link className="cancel-link" onClick={() => this.setState({ step: 'form' })}>Cancel</Link>}
-              {step === 'result' && success && <SignSuccess result={success} cb={normalizedQuery.cb} />}
+              {step === 'result' && success && <SignSuccess result={success} cb={normalizedQuery.cb || normalizedQuery.redirect_uri} />}
               {step === 'result' && error && <SignError error={error} resetForm={this.resetForm} />}
             </div>
             <div className="Sign__footer">

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -116,7 +116,7 @@
   "recover": "Recover",
   "recover_account": "Recover account",
   "recovery_account": "Recovery account",
-  "redirect_ten_seconds": "If you are not redirected within 10 seconds {link}",
+  "redirect_ten_seconds": "If you are not redirected within 10 seconds",
   "redirect_uris": "Redirect URI(s)",
   "registering_app": "registering a developer application",
   "reply_post": "Do you want to reply to {author}'s post?",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -116,7 +116,7 @@
   "recover": "Recover",
   "recover_account": "Recover account",
   "recovery_account": "Recovery account",
-  "redirect_ten_seconds": "If you are not redirected within 10 seconds {link}",
+  "redirect_ten_seconds": "If you are not redirected within 10 seconds",
   "redirect_uris": "Redirect URI(s)",
   "registering_app": "registering a developer application",
   "reply_post": "Do you want to reply to {author}'s post?",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -116,7 +116,7 @@
   "recover": "Recover",
   "recover_account": "Recover account",
   "recovery_account": "Recovery account",
-  "redirect_ten_seconds": "If you are not redirected within 10 seconds {link}",
+  "redirect_ten_seconds": "If you are not redirected within 10 seconds",
   "redirect_uris": "Redirect URI(s)",
   "registering_app": "registering a developer application",
   "reply_post": "Do you want to reply to {author}'s post?",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -116,7 +116,7 @@
   "recover": "Recover",
   "recover_account": "Recover account",
   "recovery_account": "Recovery account",
-  "redirect_ten_seconds": "If you are not redirected within 10 seconds {link}",
+  "redirect_ten_seconds": "If you are not redirected within 10 seconds",
   "redirect_uris": "Redirect URI(s)",
   "registering_app": "registering a developer application",
   "reply_post": "Do you want to reply to {author}'s post?",


### PR DESCRIPTION
Fix: the translations for the redirect link still contains the {link} but a button is now used