### PR TITLE
Remove a comma to fix a syntax error

### DIFF
--- a/helpers/token.js
+++ b/helpers/token.js
@@ -49,7 +49,7 @@ const issueAppCode = (proxy, user, scope = []) => (
 const issueAppRefreshToken = (proxy, user, scope = []) => (
   jwt.sign(
     { role: 'refresh', proxy, user, scope },
-    process.env.JWT_SECRET,
+    process.env.JWT_SECRET
   )
 );
 


### PR DESCRIPTION
'npm start' did not work due to a syntax error.