### PR TITLE
Fix error in french translation

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -137,7 +137,7 @@
   "recover": "Récupérer",
   "recover_account": "Récupérer un compte",
   "recovery_account": "Récupération d'un compte",
-  "redirect_ten_seconds": "Si vous n'est pas redirigé d'ici 10 secondes {link}",
+  "redirect_ten_seconds": "Si vous n'est pas redirigé d'ici 10 secondes",
   "redirect_uris": "URI(s) de redirection",
   "registering_app": "enregistrer une application développeur",
   "reply_post": "Voulez-vous répondre au post de {author} ?",


### PR DESCRIPTION
Error in the french translation where the parameter {link} was left