### PR TITLE
Fix the use of operator aliases that are not recommended with sequelize 4

### DIFF
--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const debug = require('debug')('sc2:server');
+const Sequelize = require('sequelize');
 const { issueAppToken, issueAppCode, issueAppRefreshToken } = require('../helpers/token');
 const { authenticate } = require('../helpers/middleware');
 const config = require('../config.json');
 
 const router = express.Router(); // eslint-disable-line new-cap
+const Op = Sequelize.Op;
 
 router.get('/oauth2/authorize', async (req, res) => {
   const redirectUri = req.query.redirect_uri;
@@ -12,7 +14,7 @@ router.get('/oauth2/authorize', async (req, res) => {
   const app = await req.db.apps.findOne({
     where: {
       client_id: clientId,
-      redirect_uris: { $contains: [redirectUri] },
+      redirect_uris: { [Op.contains]: [redirectUri] },
     },
   });
   if (!app) {


### PR DESCRIPTION
Since we had to move the version up to 4 for nsp reasons, the use of operator aliases like `$in` or `$contains` is not prohibited.