### PR TITLE
Use jussi as STEEMJS_URL default

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -21,7 +21,7 @@ function makePlugins(options) {
         NODE_ENV: isDevelopment ? JSON.stringify('development') : JSON.stringify('production'),
         ENABLE_LOGGER: JSON.stringify(process.env.ENABLE_LOGGER),
         SENTRY_PUBLIC_DSN: isDevelopment ? null : JSON.stringify(process.env.SENTRY_PUBLIC_DSN),
-        STEEMJS_URL: JSON.stringify(process.env.STEEMJS_URL || 'wss://steemd.steemit.com'),
+        STEEMJS_URL: JSON.stringify(process.env.STEEMJS_URL || 'https://api.steemit.com'),
         IS_BROWSER: JSON.stringify(true),
       },
     }),


### PR DESCRIPTION
Heroku deployment are using `wss://steemd.steemit.com` actually and request may take very long to resolve. I switch the default url to jussi (https://api.steemit.com) so we don't have this issue anymore.