### PR TITLE
Test fix for signing `account_update` transaction

### DIFF
--- a/src/components/Sign/Placeholder/Default.js
+++ b/src/components/Sign/Placeholder/Default.js
@@ -11,7 +11,7 @@ const SignPlaceholderDefault = ({
         query[param] &&
         <li key={key}>
           <strong>{changeCase.titleCase(param)}</strong>
-          <span>{query[param]}</span>
+          <span>{query[param].toString()}</span>
         </li>
       )}
     </ul>


### PR DESCRIPTION
a simple edit that goes a long way :D i need to sign `account_update` transactions via steemconnect :P and i'm guessing this is the only bug ... 

here's an example of the error https://steemconnect.com/sign/tx/W1siYWNjb3VudF91cGRhdGUiLHsiYWNjb3VudCI6InN0cmVlbWlhbiIsIm93bmVyIjp7IndlaWdodF90aHJlc2hvbGQiOjEsImFjY291bnRfYXV0aHMiOlsic3RyZWVtaWFuIiwxXSwia2V5X2F1dGhzIjpbWyJTVE03Mjh1THZTdFRlQWtZSnNRZWZrczNGWDh5Zm1wRkhwOHdYdzNSWTNrd2V5MkpHRG9vUiIsMV1dfSwiYWN0aXZlIjp7IndlaWdodF90aHJlc2hvbGQiOjEsImFjY291bnRfYXV0aHMiOlsic3RyZWVtaWFuIiwxXSwia2V5X2F1dGhzIjpbWyJTVE03Mjh1THZTdFRlQWtZSnNRZWZrczNGWDh5Zm1wRkhwOHdYdzNSWTNrd2V5MkpHRG9vUiIsMV1dfSwicG9zdGluZyI6eyJ3ZWlnaHRfdGhyZXNob2xkIjoxLCJhY2NvdW50X2F1dGhzIjpbInN0cmVlbWlhbiIsMV0sImtleV9hdXRocyI6W1siU1RNNzI4dUx2U3RUZUFrWUpzUWVma3MzRlg4eWZtcEZIcDh3WHczUlkza3dleTJKR0Rvb1IiLDFdXX0sIm1lbW9fa2V5IjoiU1RNNzI4dUx2U3RUZUFrWUpzUWVma3MzRlg4eWZtcEZIcDh3WHczUlkza3dleTJKR0Rvb1IiLCJqc29uX21ldGFkYXRhIjoie30ifV1d

the error message from react:
`Objects are not valid as a React child (found: object with keys {weight_threshold, account_auths, key_auths})`.