### PR TITLE
Fix error parsing when blockchain throws an error

### DIFF
--- a/helpers/operation.js
+++ b/helpers/operation.js
@@ -11,11 +11,12 @@ const helperOperations = require('./operations');
 
 /** Parse error message from Steemd response */
 const getErrorMessage = (error) => {
+  console.error(error);
   let errorMessage = '';
-  if (has(error, 'payload.error.data.stack[0].format')) {
-    errorMessage = error.payload.error.data.stack[0].format;
-    if (has(error, 'payload.error.data.stack[0].data')) {
-      const data = error.payload.error.data.stack[0].data;
+  if (has(error, 'data.stack[0].format')) {
+    errorMessage = error.data.stack[0].format;
+    if (has(error, 'data.stack[0].data')) {
+      const data = error.data.stack[0].data;
       Object.keys(data).forEach((d) => {
         errorMessage = errorMessage.split('${' + d + '}').join(data[d]); // eslint-disable-line prefer-template
       });

--- a/helpers/operation.js
+++ b/helpers/operation.js
@@ -11,7 +11,6 @@ const helperOperations = require('./operations');
 
 /** Parse error message from Steemd response */
 const getErrorMessage = (error) => {
-  console.error(error);
   let errorMessage = '';
   if (has(error, 'data.stack[0].format')) {
     errorMessage = error.data.stack[0].format;

--- a/src/components/Sign.js
+++ b/src/components/Sign.js
@@ -55,7 +55,6 @@ export default class Sign extends Component {
         }
         try {
           operationsParsed = JSON.parse(operationsDecoded);
-          console.log(typeof operationsParsed);
         } catch (err) {
           this.setState({ validationErrors: [{ error: 'error_tx_base64_json' }], step: 'validationErrors' });
           return;
@@ -208,6 +207,7 @@ export default class Sign extends Component {
           if (!err) {
             this.setState({ success: result });
           } else {
+            console.error(err);
             this.setState({ error: err });
           }
           this.setState({ step: 'result' });
@@ -223,6 +223,7 @@ export default class Sign extends Component {
         if (!err) {
           this.setState({ success: result });
         } else {
+          console.error(err);
           this.setState({ error: err });
         }
         this.setState({ step: 'result' });


### PR DESCRIPTION
Add a `console.error` to log the error

![image](https://user-images.githubusercontent.com/13222767/37762532-d3c65e4c-2dbc-11e8-9208-2098af498928.png)

The error text is now shown in bold

here is a request to try 
`/sign/vote?voter=ned&author=krnel&permlink=getting-too-personal-with-ai-assistants&weight=10000`