### PR TITLE
WIP: Fix smart-steem error on mobile, capitalization

### DIFF
--- a/helpers/operation.js
+++ b/helpers/operation.js
@@ -25,6 +25,7 @@ const getErrorMessage = (error) => {
 };
 
 const isOperationAuthor = (operation, query, username) => {
+  username = username.toLowerCase();
   if (Object.prototype.hasOwnProperty.call(operationAuthor, operation)) {
     const field = operationAuthor[operation];
     if (!field) { return false; }
@@ -34,6 +35,7 @@ const isOperationAuthor = (operation, query, username) => {
 };
 
 const setDefaultAuthor = (operation, query, username) => {
+  username = username.toLowerCase();
   const cQuery = cloneDeep(query);
   if (Object.prototype.hasOwnProperty.call(operationAuthor, operation)) {
     const field = operationAuthor[operation];


### PR DESCRIPTION
_I'm not setup to test this locally and I'm not sure this is the best way to do what I want._

Also this may seem trivial but I think it is important from a user-experience point of view.

Here is the issue.

- Developer makes an app with SteemConnect
- Developer tests on desktop everything works fine
- User uses on mobile, by default all text boxes on mobile auto-capitalize
- Capital in username causes error on steem

For example https://smartsteem.com/buy, if you use that on mobile it will automatically capitalize thus causing this error:

![screenshot from 2018-04-13 10-23-54](https://user-images.githubusercontent.com/9503662/38740381-639f4750-3f05-11e8-8920-a5dc9bc26609.png)

Developers can fix this by adding `autocapitalize="none"` to the `input`.

But there are so many steemconnect apps out there now. Maybe we could fix them all at once by converting usernames to call lowercase before processing.